### PR TITLE
Fixes issue #26: Unrecognized font family 'ionicons'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import { AppRegistry } from 'react-native';
 import App from './App';
+import { registerRootComponent } from 'expo';
 
-AppRegistry.registerComponent('main', () => App);
+registerRootComponent(App);
+


### PR DESCRIPTION
I was having issues getting ionicons to work as it was in the tutorial. 

I found the following fix that worked for me [here](https://github.com/expo/expo/issues/1752)

It's also how [Expo has it](https://github.com/expo/expo/blob/master/packages/expo/AppEntry.js)